### PR TITLE
Add dispatcher

### DIFF
--- a/components/core/NumericRangeFacet.jsx
+++ b/components/core/NumericRangeFacet.jsx
@@ -121,6 +121,9 @@ const NumericRangeFacet = ({ field, facet }) => {
 
     function handleSliderChange(_, newValues) {
         setValues(newValues)
+        if (GoogleTagManager && GoogleTagManager.dispatch) {
+            GoogleTagManager.dispatch({data: newValues, event: _, key: 'numericFacets'})
+        }
     }
 
     function handleSliderCommitted(_, newValues) {


### PR DESCRIPTION
Change log:
1. Use dispatcher method to send change events to GTM plugin.

Note:
`DOMSubtreeModified` seems to have been not just deprecated, but completed removed from Chrome. So tracking of slider can no longer be done independently unless through some cumbersome workaround with Mutations observer.